### PR TITLE
Fix bug when parse() is used in Rails 3

### DIFF
--- a/lib/tropo-webapi-ruby/tropo-webapi-ruby-helpers.rb
+++ b/lib/tropo-webapi-ruby/tropo-webapi-ruby-helpers.rb
@@ -209,7 +209,7 @@ module Tropo
       # @param[Hash] the newly created hash that contins the properly formatted key
       def transform_pair(key, value)
         hash = { decamelize(key) => value }
-        hash['timestamp'] = Time.parse(value) if hash['timestamp']
+        hash['timestamp'] = Time.parse(value) if hash['timestamp'] and hash['timestamp'].kind_of? String
         if hash['actions']
           if hash['actions']['name']
             key_name = hash['actions']['name']

--- a/spec/tropo-webapi-ruby_spec.rb
+++ b/spec/tropo-webapi-ruby_spec.rb
@@ -415,7 +415,7 @@ describe "Tropo" do
     hash = Tropo::Generator.parse(json_session)
     hash[:session][:timestamp].should == Time.parse("2010-01-19T23:18:48.562Z")
   end
-  
+
   it "should build a Ruby hash object when a result arrives in JSON with one action returned in an array" do
     json_result = "{\"result\":{\"sessionId\":\"CCFD9C86-1DD1-11B2-B76D-B9B253E4B7FB@161.253.55.20\",\"callState\":\"ANSWERED\",\"sessionDuration\":2,\"sequence\":1,\"complete\":true,\"error\":null,\"actions\":{\"name\":\"zip\",\"attempts\":1,\"disposition\":\"SUCCESS\",\"confidence\":100,\"interpretation\":\"12345\",\"utterance\":\"1 2 3 4 5\"}}}"
     hash = Tropo::Generator.parse(json_result)
@@ -629,7 +629,16 @@ describe "Tropo" do
     tropo = Tropo::Generator.parse(JSON.parse(json_session))
     tropo.session.user_type.should == 'HUMAN'
   end
-  
+
+  it "should correctly parse a Ruby Hash with an instantiated Ruby Time object as timestamp" do
+    json_session = "{\"session\":{\"id\":\"dih06n\",\"accountId\":\"33932\",\"timestamp\":\"2010-01-19T23:18:48.562Z\",\"userType\":\"HUMAN\",\"to\":{\"id\":\"tropomessaging@bot.im\",\"name\":\"unknown\",\"channel\":\"TEXT\",\"network\":\"JABBER\"},\"from\":{\"id\":\"john_doe@gmail.com\",\"name\":\"unknown\",\"channel\":\"TEXT\",\"network\":\"JABBER\"}}}"
+    tropo = JSON.parse(json_session)
+    tropo['session']['timestamp'] = Time.parse("2010-01-19T23:18:48.562Z")
+
+    hash = Tropo::Generator.parse(tropo)
+    hash[:session][:timestamp].should == Time.parse("2010-01-19T23:18:48.562Z")
+  end
+
   it "should return a hash of the response object" do
     result = Tropo::Generator.new do
       say [{ :value => '1234' }, { :value => 'abcd', :event => "nomatch:1" }]


### PR DESCRIPTION
Rails 3 parses JSON and translates a timestamp to a Time object automagically, when using the `params` variable in a Controller. When tropo-webapi-ruby tries to `Time::parse` it again, an error is generated:

```
    NoMethodError: undefined method `gsub!' for 2011-06-13 00:51:38 +0200:Time
```

I modified the code so that the library just ignores it if it's already a Time object.
