### PR TITLE
Add license to gemspec

### DIFF
--- a/tropo-webapi-ruby.gemspec
+++ b/tropo-webapi-ruby.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
     "tropo-webapi-ruby.gemspec"
   ]
   s.homepage = %q{http://tropo.com}
+  s.license = %q{MIT}
   s.require_paths = ["lib"]
   s.required_ruby_version = Gem::Requirement.new(">= 1.8.6")
   s.rubygems_version = %q{1.5.0}


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.